### PR TITLE
Do not allow transfers to the LZ endpoint as it is not needed

### DIFF
--- a/contracts/Titn.sol
+++ b/contracts/Titn.sol
@@ -79,8 +79,7 @@ contract Titn is OFT {
             to != transferAllowedContract && // Allow transfers to the transferAllowedContract
             isBridgedTokensTransferLocked && // Check if bridged transfers are locked
             // Restrict bridged token holders OR apply Arbitrum-specific restriction
-            (isBridgedTokenHolder[from] || block.chainid == arbitrumChainId) &&
-            to != lzEndpoint // Allow transfers to LayerZero endpoint
+            (isBridgedTokenHolder[from] || block.chainid == arbitrumChainId)
         ) {
             revert BridgedTokensTransferLocked();
         }


### PR DESCRIPTION
Related to finding [S-240](https://code4rena.com/evaluate/2025-02-thorwallet/findings/S-240)

_`TITN` tokens transferred to the `LayerZero` endpoint address will be lost_