### PR TITLE
Only allow bridging to the sender's own address

### DIFF
--- a/contracts/Titn.sol
+++ b/contracts/Titn.sol
@@ -116,8 +116,10 @@ contract Titn is OFT {
         MessagingFee calldata _fee,
         address _refundAddress
     ) internal virtual override returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {
-        // Enforce bridging to the same address that is sending from source:
-        require(_sendParam.to == bytes32(uint256(uint160(msg.sender))), "Must bridge to your own address");
+        // Enforce bridging to the same address that is sending from source during the locked period:
+        if (isBridgedTokensTransferLocked) {
+            require(_sendParam.to == bytes32(uint256(uint160(msg.sender))), "Must bridge to your own address");
+        }
 
         // then proceed with the normal default logic
         (uint256 amountSentLD, uint256 amountReceivedLD) = _debit(

--- a/contracts/Titn.sol
+++ b/contracts/Titn.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.22;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { OFT } from "@layerzerolabs/oft-evm/contracts/OFT.sol";
+import { SendParam, MessagingFee, MessagingReceipt, OFTReceipt } from "@layerzerolabs/oft-evm/contracts/interfaces/IOFT.sol";
 
 contract Titn is OFT {
     // Bridged token holder may have transfer restricted
@@ -108,5 +109,28 @@ contract Titn is OFT {
 
         // In the case of NON-default OFT, the _amountLD MIGHT not be == amountReceivedLD.
         return _amountLD;
+    }
+
+    function _send(
+        SendParam calldata _sendParam,
+        MessagingFee calldata _fee,
+        address _refundAddress
+    ) internal virtual override returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {
+        // Enforce bridging to the same address that is sending from source:
+        require(_sendParam.to == bytes32(uint256(uint160(msg.sender))), "Must bridge to your own address");
+
+        // then proceed with the normal default logic
+        (uint256 amountSentLD, uint256 amountReceivedLD) = _debit(
+            msg.sender,
+            _sendParam.amountLD,
+            _sendParam.minAmountLD,
+            _sendParam.dstEid
+        );
+
+        (bytes memory message, bytes memory options) = _buildMsgAndOptions(_sendParam, amountReceivedLD);
+        msgReceipt = _lzSend(_sendParam.dstEid, message, options, _fee, _refundAddress);
+
+        oftReceipt = OFTReceipt(amountSentLD, amountReceivedLD);
+        emit OFTSent(msgReceipt.guid, _sendParam.dstEid, msg.sender, amountSentLD, amountReceivedLD);
     }
 }

--- a/contracts/Titn.sol
+++ b/contracts/Titn.sol
@@ -79,8 +79,7 @@ contract Titn is OFT {
             to != transferAllowedContract && // Allow transfers to the transferAllowedContract
             isBridgedTokensTransferLocked && // Check if bridged transfers are locked
             // Restrict bridged token holders OR apply Arbitrum-specific restriction
-            (isBridgedTokenHolder[from] || block.chainid == arbitrumChainId) &&
-            to != lzEndpoint // Allow transfers to LayerZero endpoint
+            (isBridgedTokenHolder[from] || block.chainid == arbitrumChainId)
         ) {
             revert BridgedTokensTransferLocked();
         }

--- a/test/hardhat/MergeTgt.test.ts
+++ b/test/hardhat/MergeTgt.test.ts
@@ -16,7 +16,6 @@ describe('MergeTgt tests', function () {
     let Tgt: ContractFactory
     let EndpointV2Mock: ContractFactory
     let ownerA: SignerWithAddress
-    let ownerB: SignerWithAddress
     let endpointOwner: SignerWithAddress
     let user1: SignerWithAddress
     let user2: SignerWithAddress
@@ -35,7 +34,7 @@ describe('MergeTgt tests', function () {
         Tgt = await ethers.getContractFactory('Tgt')
         // Fetching the first three signers (accounts) from Hardhat's local Ethereum network
         const signers = await ethers.getSigners()
-        ;[ownerA, ownerB, endpointOwner, user1, user2, user3] = signers
+        ;[ownerA, endpointOwner, user1, user2, user3] = signers
         // The EndpointV2Mock contract comes from @layerzerolabs/test-devtools-evm-hardhat package
         // and its artifacts are connected as external artifacts to this project
         const EndpointV2MockArtifact = await deployments.getArtifact('EndpointV2Mock')
@@ -58,7 +57,7 @@ describe('MergeTgt tests', function () {
             'arbTitn',
             'arbTITN',
             mockEndpointV2B.address,
-            ownerB.address,
+            ownerA.address,
             ethers.utils.parseUnits('0', 18)
         )
         // Setting destination endpoints in the LZEndpoint mock for each TITN instance
@@ -66,7 +65,7 @@ describe('MergeTgt tests', function () {
         await mockEndpointV2B.setDestLzEndpoint(baseTITN.address, mockEndpointV2A.address)
         // Setting each TITN instance as a peer of the other in the mock LZEndpoint
         await baseTITN.connect(ownerA).setPeer(eidB, ethers.utils.zeroPad(arbTITN.address, 32))
-        await arbTITN.connect(ownerB).setPeer(eidA, ethers.utils.zeroPad(baseTITN.address, 32))
+        await arbTITN.connect(ownerA).setPeer(eidA, ethers.utils.zeroPad(baseTITN.address, 32))
 
         // Defining the amount of tokens to send and constructing the parameters for the send operation
         const tokensToSend = ethers.utils.parseEther('173700000')
@@ -74,7 +73,7 @@ describe('MergeTgt tests', function () {
         const options = Options.newOptions().addExecutorLzReceiveOption(200000, 0).toHex().toString()
         const sendParam = [
             eidB,
-            ethers.utils.zeroPad(ownerB.address, 32),
+            ethers.utils.zeroPad(ownerA.address, 32),
             tokensToSend,
             tokensToSend,
             options,
@@ -87,24 +86,24 @@ describe('MergeTgt tests', function () {
         await baseTITN.send(sendParam, [nativeFee, 0], ownerA.address, { value: nativeFee })
 
         // Deply MockTGT contract
-        tgt = await Tgt.deploy('Tgt', 'TGT', ownerB.address, ethers.utils.parseUnits('1000000000', 18))
+        tgt = await Tgt.deploy('Tgt', 'TGT', ownerA.address, ethers.utils.parseUnits('1000000000', 18))
 
         // Deploy MergeTgt contract
-        mergeTgt = await MergeTgt.deploy(tgt.address, arbTITN.address, ownerB.address)
+        mergeTgt = await MergeTgt.deploy(tgt.address, arbTITN.address, ownerA.address)
 
         // Arbitrum setup
-        await arbTITN.connect(ownerB).setTransferAllowedContract(mergeTgt.address)
-        await mergeTgt.connect(ownerB).setLaunchTime()
-        await mergeTgt.connect(ownerB).setLockedStatus(1)
+        await arbTITN.connect(ownerA).setTransferAllowedContract(mergeTgt.address)
+        await mergeTgt.connect(ownerA).setLaunchTime()
+        await mergeTgt.connect(ownerA).setLockedStatus(1)
 
         // now the admin should deposit all ARB.TITN into the mergeTGT contract
-        await arbTITN.connect(ownerB).approve(mergeTgt.address, ethers.utils.parseUnits('173700000', 18))
-        await mergeTgt.connect(ownerB).deposit(arbTITN.address, ethers.utils.parseUnits('173700000', 18))
+        await arbTITN.connect(ownerA).approve(mergeTgt.address, ethers.utils.parseUnits('173700000', 18))
+        await mergeTgt.connect(ownerA).deposit(arbTITN.address, ethers.utils.parseUnits('173700000', 18))
 
         // let's send some TGT to user1 and user2
-        await tgt.connect(ownerB).transfer(user1.address, ethers.utils.parseUnits('1000', 18))
-        await tgt.connect(ownerB).transfer(user2.address, ethers.utils.parseUnits('1000', 18))
-        await tgt.connect(ownerB).transfer(user3.address, ethers.utils.parseUnits('1000', 18))
+        await tgt.connect(ownerA).transfer(user1.address, ethers.utils.parseUnits('1000', 18))
+        await tgt.connect(ownerA).transfer(user2.address, ethers.utils.parseUnits('1000', 18))
+        await tgt.connect(ownerA).transfer(user3.address, ethers.utils.parseUnits('1000', 18))
     })
 
     describe('General tests', function () {


### PR DESCRIPTION
Related to finding [F-9](https://code4rena.com/evaluate/2025-02-thorwallet/findings/F-9)

_The user can send tokens to any address by using two bridge transfers, even when transfers are restricted._